### PR TITLE
LabelEdition: keep calibration of input image

### DIFF
--- a/src/main/java/inra/ijpb/plugins/LabelEdition.java
+++ b/src/main/java/inra/ijpb/plugins/LabelEdition.java
@@ -570,6 +570,7 @@ public class LabelEdition implements PlugIn
 				inputStackCopy );
 		displayImage.setTitle( "Label Edition" );
 		displayImage.setSlice( inputImage.getSlice() );
+		displayImage.setCalibration( inputImage.getCalibration() );
 
 		// hide input image (to avoid accidental closing)
 		inputImage.getWindow().setVisible( false );


### PR DESCRIPTION
Currently, the Label Edition plugin removes the calibration from the input image. I don't see any obvious reason, why this should be the case (at least for the cases that I have tested).

This PR transfers the calibration from the input image to the output image.