### PR TITLE
Adds a convenience Static Class to append ResultsTables

### DIFF
--- a/src/main/java/inra/ijpb/measure/ResultsBuilder.java
+++ b/src/main/java/inra/ijpb/measure/ResultsBuilder.java
@@ -1,0 +1,42 @@
+package inra.ijpb.measure;
+
+import ij.measure.ResultsTable;
+
+/**
+ * Builder-type class to hold results
+ * Basically it will keep appending results to a larger results table
+ * Built in a way where we can chain them together
+ * @author oburri
+ *
+ */
+
+public class ResultsBuilder {
+	
+	private ResultsTable allResults;
+	
+	public ResultsBuilder() { this.allResults = new ResultsTable();	}
+	public ResultsBuilder(ResultsTable rt) { this.allResults = rt; }
+	
+	public ResultsBuilder addResult (ResultsTable rt) {
+		// Keep the label and everything in the same order as before, but just append whatever columns do not exist yet
+		if(allResults.size() == rt.size() ) {
+			for(int c=0; c<=rt.getLastColumn(); c++) {
+				String colName = rt.getColumnHeading(c);
+				if( !allResults.columnExists(colName)) {
+					for(int i=0; i<rt.getCounter(); i++) {
+						allResults.setValue(colName, i, rt.getValue(colName, i)); // Currently only supports numbered results...
+						allResults.updateResults();
+					}
+				}
+			}
+		} else { // Overwrite
+			this.allResults = rt;
+		}
+		
+		return this;
+	}
+	
+	public ResultsTable getResultsTable() {
+		return this.allResults;
+	}
+}

--- a/src/test/java/inra/ijpb/measure/AllTests.java
+++ b/src/test/java/inra/ijpb/measure/AllTests.java
@@ -34,6 +34,7 @@ import org.junit.runners.Suite;
 	GeometricMeasures3DTest.class,
 	GeometryUtilsTest.class,
 	Vector3dTest.class,
+	ResultsBuilderTest.class,
 	})
 public class AllTests {
   //nothing

--- a/src/test/java/inra/ijpb/measure/ResultsBuilderTest.java
+++ b/src/test/java/inra/ijpb/measure/ResultsBuilderTest.java
@@ -1,0 +1,58 @@
+package inra.ijpb.measure;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import ij.measure.ResultsTable;
+
+public class ResultsBuilderTest {
+
+	@Test
+	public final void testAppendResults() 
+	{
+		ResultsTable rt1 = new ResultsTable();
+		ResultsTable rt2 = new ResultsTable();
+		ResultsTable rt3 = new ResultsTable();
+		
+		ResultsTable rt_final = new ResultsTable();
+		
+		
+		// Populate Results
+		for (int i=0; i<20; i++)
+		{
+			rt1.incrementCounter();
+			rt2.incrementCounter();
+			rt3.incrementCounter();
+			rt_final.incrementCounter();
+			
+			rt1.setLabel("Row #"+(i+1), i);
+			rt2.setLabel("Row #"+(i+1), i);
+			rt3.setLabel("Row #"+(i+1), i);
+			rt_final.setLabel("Row #"+(i+1), i);
+			
+			rt1.addValue("Metric 1", (i+1)* 10);
+			rt2.addValue("Metric 2", (i+1)* 100);
+			rt3.addValue("Metric 3", (i+1)* 1000);
+			
+			rt_final.addValue("Metric 1", (i+1)* 10);
+			rt_final.addValue("Metric 2", (i+1)* 100);
+			rt_final.addValue("Metric 3", (i+1)* 1000);
+			
+		}
+		
+		ResultsTable built_results = new ResultsBuilder().addResult(rt3).addResult(rt2).addResult(rt1).getResultsTable();
+		
+		// Check equal sizes
+		assertEquals(built_results.size(), rt1.size());
+		
+		assertEquals(built_results.getLastColumn(), rt_final.getLastColumn());
+				
+		for (int i=0; i<20; i++)
+		{
+			assertEquals(built_results.getValue("Metric 1", i), rt1.getValue("Metric 1", i), 0.0);
+			assertEquals(built_results.getValue("Metric 2", i), rt2.getValue("Metric 2", i), 0.0);
+			assertEquals(built_results.getValue("Metric 3", i), rt3.getValue("Metric 3", i), 0.0);
+		}
+	}
+}


### PR DESCRIPTION
This helps combine results tables together.

Please let me know if this makes sense to you, or let me know what would be an easier way to combine results

Best

Oli

See the groovy code below as an example
```
import inra.ijpb.binary.*
import inra.ijpb.label.*
import inra.ijpb.measure.*
import ij.IJ
import ij.ImagePlus

def imp = IJ.openImage("http://imagej.nih.gov/ij/images/blobs.gif");

def img = imp.duplicate()
IJ.setAutoThreshold(img, "Triangle dark stack")
IJ.setAutoThreshold(img, "Default");
IJ.run(img, "Convert to Mask", "");
IJ.run(img, "Fill Holes", "stack")
IJ.run(img, "Watershed", "stack")

def labels = new ImagePlus("Labeled Image", BinaryImages.componentsLabeling( img.getProcessor(), 6, 32 ))

def im = new IntensityMeasures(imp, labels)

def res_mean = im.getMean()
double[] resol = new double[3]
resol[0] = 1;
resol[1] = 1;
resol[2] = 1;

new ResultsBuilder()
		.addResult(new LabeledVoxelsMeasure(imp, labels).getSumOfVoxels())
		.addResult(new IntensityMeasures(imp, labels).getMean())
		.getResultsTable()
		.show("Concatenated Results")
```