### PR TITLE
Fix the Travis CI tests

### DIFF
--- a/src/test/java/inra/ijpb/measure/region2d/OrientedBoundingBox2DTest.java
+++ b/src/test/java/inra/ijpb/measure/region2d/OrientedBoundingBox2DTest.java
@@ -80,9 +80,6 @@ public class OrientedBoundingBox2DTest
 	@Test
 	public final void testAnalyzeRegions_circles()
 	{
-		@SuppressWarnings("unused")
-		ImageJ ij = new ImageJ();
-		
 		String fileName = getClass().getResource("/files/circles.tif").getFile();
 		ImagePlus imagePlus = IJ.openImage(fileName);
 		assertNotNull(imagePlus);


### PR DESCRIPTION
See [Travis build error](https://travis-ci.org/ijpb/MorphoLibJ/builds/407171422)

Remove the unused ImageJ instance. 
This element was crashing the Travis Unit testing step: the current ImageJ instance requires a X11 server (that does not exist on the Travis CI).

The following Raw log was displayed:

```sh
Results :

Tests in error: 
  OrientedBoundingBox2DTest.testAnalyzeRegions_circles:84 Â» Headless 
No X11 DIS...
```

